### PR TITLE
Add binding for WebKit to build

### DIFF
--- a/iOSVirus.xcodeproj/project.pbxproj
+++ b/iOSVirus.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		D0A2DFA521C986FD0064D61F /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D0A2DFA321C986FD0064D61F /* LaunchScreen.storyboard */; };
 		D0A2DFAD21C98FAA0064D61F /* ErrorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0A2DFAC21C98FAA0064D61F /* ErrorViewController.swift */; };
 		D0A2DFB021C98FC70064D61F /* WebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0A2DFAF21C98FC70064D61F /* WebViewController.swift */; };
+		D0BAD241234E229E00BA3475 /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D0BAD240234E229E00BA3475 /* WebKit.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -31,6 +32,7 @@
 		D0A2DFA621C986FD0064D61F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		D0A2DFAC21C98FAA0064D61F /* ErrorViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorViewController.swift; sourceTree = "<group>"; };
 		D0A2DFAF21C98FC70064D61F /* WebViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewController.swift; sourceTree = "<group>"; };
+		D0BAD240234E229E00BA3475 /* WebKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WebKit.framework; path = System/Library/Frameworks/WebKit.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -38,6 +40,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D0BAD241234E229E00BA3475 /* WebKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -59,6 +62,7 @@
 			children = (
 				D0A2DF9921C986FC0064D61F /* iOSVirus */,
 				D0A2DF9821C986FC0064D61F /* Products */,
+				D0BAD23F234E229D00BA3475 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -93,6 +97,14 @@
 				D0A2DFAF21C98FC70064D61F /* WebViewController.swift */,
 			);
 			path = Views;
+			sourceTree = "<group>";
+		};
+		D0BAD23F234E229D00BA3475 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				D0BAD240234E229E00BA3475 /* WebKit.framework */,
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */


### PR DESCRIPTION
Something must have changed recently to require explicit incorporation of WebKit to a project's build.  This commit adds that so that the build no longer breaks.

Resolves #7